### PR TITLE
Use more accurate version constraints on `base`

### DIFF
--- a/alist.cabal
+++ b/alist.cabal
@@ -60,7 +60,7 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       base <10000
+  build-depends:       base >= 4.9 && < 5
   
   -- Directories containing source files.
   -- hs-source-dirs:      


### PR DESCRIPTION
Various releases of  `alist` had issues as can be seen at 

https://matrix.hackage.haskell.org/package/alist@1550400112

In my function as Hackage Trustee I've manually fixed up the affected releases via [Hackage Metadata Revisions](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md):

 - https://hackage.haskell.org/package/alist-0.1.0.1/revisions/
 - https://hackage.haskell.org/package/alist-0.1.0.2/revisions/
 - https://hackage.haskell.org/package/alist-0.1.0.3/revisions/
 - https://hackage.haskell.org/package/alist-0.1.0.4/revisions/
 - https://hackage.haskell.org/package/alist-0.1.0.5/revisions/

You can inspect the resulting build matrix report at

https://matrix.hackage.haskell.org/package/alist@1550402636

Please let me know if you have any question.
